### PR TITLE
fix: 시계 그림 그리기 붓 굵기 조정 #77

### DIFF
--- a/frontend/src/pages/DrawingPage.tsx
+++ b/frontend/src/pages/DrawingPage.tsx
@@ -198,7 +198,7 @@ const DrawingPage: React.FC = () => {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
     ctx.strokeStyle = "#FFFFFF";
-    ctx.lineWidth = 5;
+    ctx.lineWidth = 3;
     ctx.lineCap = "round";
     ctx.beginPath();
     ctx.moveTo(pos.x, pos.y);
@@ -241,7 +241,7 @@ const DrawingPage: React.FC = () => {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
     ctx.strokeStyle = "#FFFFFF";
-    ctx.lineWidth = 5;
+    ctx.lineWidth = 3;
     ctx.lineCap = "round";
   };
 


### PR DESCRIPTION
## 📌 PR 제목
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 문서 변경
- [ ] 기타

## 📋 작업한 내용
시계 그리기의 선 굵기를 줄임.

## 📸 Swagger 캡처 (필수)
<!-- Swagger에서 캡처한 이미지 넣어주세요 -->
> 예시:
> ![swagger](https://user-images.githubusercontent.com/example.png)

## 🧪 테스트 여부
- [ ] Swagger로 API 동작 확인
- [ ] 기타 테스트 완료

## 🔗 관련 이슈
- Close #

