### PR TITLE
Fix/ad8questionbox 89

### DIFF
--- a/frontend/src/pages/AD8Page.tsx
+++ b/frontend/src/pages/AD8Page.tsx
@@ -199,6 +199,9 @@ const QuestionCard = styled.div`
   box-shadow: 0 2px 38px 0 #96e7d410;
   margin: 0 auto;
   width: 100%;
+  min-width: 600px; /* 기존보다 더 넓게 수정 */
+  margin-right: 300px;
+  margin-left: 300px
 `;
 
 const QuestionNumber = styled.div`

--- a/frontend/src/pages/AD8Page.tsx
+++ b/frontend/src/pages/AD8Page.tsx
@@ -164,7 +164,7 @@ const Subtitle = styled.p`
 
 const ProgressContainer = styled.div`
   margin-bottom: 3vh;
-  width: 100%;
+  width: 650px;
 `;
 
 const ProgressLabel = styled.div`


### PR DESCRIPTION
## 📌 PR 제목
- [ ] 기능 추가
- [x] 버그 수정
- [x] 문서 변경
- [ ] 기타

## 📋 작업한 내용
ad8테스트에서 질문 상자가 늘어나지 않도록 함.
늘어난 상자에 맞게 진행도 바 늘림.

## 📸 Swagger 캡처 (필수)
<!-- Swagger에서 캡처한 이미지 넣어주세요 -->
> 예시:
> ![swagger](https://user-images.githubusercontent.com/example.png)

## 🧪 테스트 여부
- [ ] Swagger로 API 동작 확인
- [ ] 기타 테스트 완료

## 🔗 관련 이슈
- Close #

