### PR TITLE
fix: 그림그리기에서 그림 제출하면 그림 그리기 카드가 나타나도록 수정. #100

### DIFF
--- a/frontend/src/pages/DrawingPage.tsx
+++ b/frontend/src/pages/DrawingPage.tsx
@@ -255,7 +255,7 @@ const DrawingPage: React.FC = () => {
   // 제출
   const handleSubmit = () => {
     alert("그림이 제출되었습니다. (기능 구현 대기 중)");
-    navigate(-1); // 이전 페이지로 이동
+    navigate('/main', { state: { cardIndex: 2 } }); // 이전 페이지로 이동
   };
 
   return (


### PR DESCRIPTION
## 📌 PR 제목
- [ ] 기능 추가
- [x] 버그 수정
- [x] 문서 변경
- [ ] 기타

## 📋 작업한 내용
그림 그리기에서 제출하기 버튼을 누르면 그림 그리기 카드가 중앙에 오도록 수정.

## 📸 Swagger 캡처 (필수)
<!-- Swagger에서 캡처한 이미지 넣어주세요 -->
> 예시:
> ![swagger](https://user-images.githubusercontent.com/example.png)

## 🧪 테스트 여부
- [ ] Swagger로 API 동작 확인
- [ ] 기타 테스트 완료

## 🔗 관련 이슈
- Close #

