### PR TITLE
Fix/connect ad8 to report-106

### DIFF
--- a/backend/app/ad8/api.py
+++ b/backend/app/ad8/api.py
@@ -1,11 +1,14 @@
-from fastapi import APIRouter, HTTPException
-from .schemas import AD8Request, AD8Result
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+from app.database import get_db
+from . import schemas
+from . import service
 
 router = APIRouter()
 
 @router.post(
     "/ad8",
-    response_model=AD8Result,
+    response_model=schemas.AD8Result,
     status_code=201,
     responses={
         400: {
@@ -20,10 +23,8 @@ router = APIRouter()
         }
     }
 )
-def submit_ad8(data: AD8Request):
+def submit_ad8(data: schemas.AD8Request, db: Session = Depends(get_db)):
     if not data.responses:
         raise HTTPException(status_code=400, detail="responses는 최소 1개 이상의 응답을 포함해야 합니다.")
     
-    risk_score = sum(not r.isCorrect for r in data.responses)
-    message = "치매 위험이 있습니다." if risk_score >= 2 else "정상 범위입니다."
-    return {"risk_score": risk_score, "message": message}
+    return service.process_ad8_test(db=db, data=data)

--- a/backend/app/ad8/crud.py
+++ b/backend/app/ad8/crud.py
@@ -1,12 +1,12 @@
 from sqlalchemy.orm import Session
-from .models import AD8Test, AD8Response
-from .schemas import AD8Request
+from . import models
+from . import schemas
 
-def create_ad8_test(db: Session, data: AD8Request, risk_score: int):
+def create_ad8_test(db: Session, data: schemas.AD8Request, risk_score: int):
     # AD8Test 테이블에 먼저 저장
-    ad8_test = AD8Test(
-        report_id = data.reportId,
-        risk_score = risk_score
+    ad8_test = models.AD8Test(
+        report_id=data.report_id,
+        risk_score=risk_score
     )
     db.add(ad8_test)
     db.commit()
@@ -14,10 +14,10 @@ def create_ad8_test(db: Session, data: AD8Request, risk_score: int):
 
     # 각 질문 응답을 AD8Response 테이블에 저장
     for r in data.responses:
-        response = AD8Response(
-            ad8test_id = ad8_test.ad8test_id,
-            question_no = r.questionNo,
-            is_correct = r.isCorrect
+        response = models.AD8Response(
+            AD8Test_id=ad8_test.AD8Test_id,
+            question_no=r.question_no,
+            is_correct=r.is_correct
         )
         db.add(response)
 

--- a/backend/app/ad8/models.py
+++ b/backend/app/ad8/models.py
@@ -4,15 +4,15 @@ from app.database import Base
 class AD8Test(Base):
     __tablename__ = "ad8_test"
 
-    ad8test_id = Column(Integer, primary_key=True, index=True)
-    # report_id = Column(Integer, ForeignKey("report.report_id"), nullable=False)
+    AD8Test_id = Column(Integer, primary_key=True, index=True)
+    report_id = Column(Integer, ForeignKey("reports.report_id"), nullable=False)
     risk_score = Column(Integer, nullable=False)
 
 class AD8Response(Base):
     __tablename__ = "ad8_response"
 
     response_id = Column(Integer, primary_key=True, index=True)
-    ad8test_id = Column(Integer, ForeignKey("ad8_test.ad8test_id"), nullable=False)
+    AD8Test_id = Column(Integer, ForeignKey("ad8_test.AD8Test_id"), nullable=False)
     question_no = Column(Integer, nullable=False)
     is_correct = Column(Boolean, nullable=False)
 

--- a/backend/app/ad8/schemas.py
+++ b/backend/app/ad8/schemas.py
@@ -1,13 +1,40 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 from typing import List
 
-class ResponseItem(BaseModel):
-    questionNo: int
-    isCorrect: bool
+class CamelCaseModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+    )
+
+class ResponseItem(CamelCaseModel):
+    question_no: int
+    is_correct: bool
 
 class AD8Request(BaseModel):
-    reportId: int
+    report_id: int
     responses: List[ResponseItem]
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "report_id": 1,
+                    "responses": [
+                        {"questionNo": 1, "isCorrect": True},
+                        {"questionNo": 2, "isCorrect": False},
+                        {"questionNo": 3, "isCorrect": True},
+                        {"questionNo": 4, "isCorrect": False},
+                        {"questionNo": 5, "isCorrect": True},
+                        {"questionNo": 6, "isCorrect": True},
+                        {"questionNo": 7, "isCorrect": False},
+                        {"questionNo": 8, "isCorrect": True},
+                    ],
+                }
+            ]
+        }
+    )
 
 class AD8Result(BaseModel):
     risk_score: int

--- a/backend/app/ad8/service.py
+++ b/backend/app/ad8/service.py
@@ -1,8 +1,34 @@
-from .schemas import AD8Request
+from sqlalchemy.orm import Session
+from . import schemas as ad8_schemas
+from . import crud as ad8_crud
+from app.report import crud as report_crud
 
-def calculate_ad8_risk_score(data: AD8Request) -> int:
-    # isCorrect == False인 응답 개수를 점수로 계산
-    return sum(not r.isCorrect for r in data.responses)
+def get_ad8_opinion(score: int) -> str:
+    if 0 <= score <= 1:
+        return "AD8 검사 결과, 피검자의 인지 기능은 정상 범위로 판단됩니다. 현재로서는 별도의 조치가 필요하지 않습니다."
+    elif 2 <= score <= 3:
+        return "경미한 인지 저하 가능성이 관찰됩니다. 정기적인 모니터링과 생활습관 관리가 권장됩니다."
+    elif 4 <= score <= 5:
+        return "인지 기능 저하가 뚜렷이 의심되며, 신경과 전문의와의 상담 및 정밀 평가를 권장드립니다."
+    else: # 6~8점
+        return "심각한 인지 저하 징후가 확인되었습니다. 가능한 한 조속한 시일 내 전문적인 진단 및 치료 계획 수립이 필요합니다."
 
-def get_ad8_result_message(score: int) -> str:
-    return "치매 위험이 있습니다." if score >= 2 else "정상 범위입니다."
+def process_ad8_test(db: Session, data: ad8_schemas.AD8Request):
+    # 1. 점수 계산 (is_correct가 True인 항목의 개수를 셉니다)
+    risk_score = sum(r.is_correct for r in data.responses)
+
+    # 2. 점수에 따른 소견 생성
+    opinion = get_ad8_opinion(risk_score)
+
+    # 3. reports 테이블에 점수와 소견 업데이트
+    report_crud.update_report_ad8_result(
+        db=db,
+        report_id=data.report_id,
+        risk_score=risk_score,
+        ad8_opinion=opinion
+    )
+
+    # 4. AD8 자체 테이블에도 저장
+    ad8_crud.create_ad8_test(db=db, data=data, risk_score=risk_score)
+
+    return {"risk_score": risk_score, "message": opinion}

--- a/backend/app/report/api.py
+++ b/backend/app/report/api.py
@@ -5,7 +5,7 @@ from . import schemas, service
 
 router = APIRouter()
 
-@router.post("/reports/empty", response_model=schemas.ReportResponse)
+@router.post("/empty", response_model=schemas.ReportResponse)
 def create_empty_report(report: schemas.ReportCreate, db: Session = Depends(get_db)):
-    new_report = service.create_empty_report_service(db, report)
+    new_report = service.create_report_service(db, report)
     return new_report

--- a/backend/app/report/crud.py
+++ b/backend/app/report/crud.py
@@ -1,17 +1,19 @@
 from sqlalchemy.orm import Session
 from . import models, schemas
 
-def create_empty_report(db: Session, report: schemas.ReportCreate):
-    new_report = models.Report(
-        user_id=report.user_id,
-        drawingtest_result=report.drawingtest_result,
-        chat_result=report.chat_result,
-        ad8test_result=report.ad8test_result,
-        soundtest_result=report.soundtest_result,
-        recommendation=report.recommendation,
-        total_score=report.total_score,
-    )
-    db.add(new_report)
+def create_report(db: Session, report: schemas.ReportCreate):
+    db_report = models.Report(**report.model_dump())
+    db.add(db_report)
     db.commit()
-    db.refresh(new_report)
-    return new_report
+    db.refresh(db_report)
+    return db_report
+
+def update_report_ad8_result(db: Session, report_id: int, risk_score: int, ad8_opinion: str):
+    db_report = db.query(models.Report).filter(models.Report.report_id == report_id).first()
+    if db_report:
+        db_report.total_score = risk_score
+        db_report.recommendation = ad8_opinion
+        db_report.ad8test_result = ad8_opinion # ad8test_result에도 동일하게 저장
+        db.commit()
+        db.refresh(db_report)
+    return db_report

--- a/backend/app/report/models.py
+++ b/backend/app/report/models.py
@@ -4,7 +4,7 @@ from app.database import Base
 from app.auth.models import User
 
 class Report(Base):
-    __tablename__ = "reports"  # 테이블명 소문자 복수형으로 통일
+    __tablename__ = "reports"
 
     report_id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
@@ -13,18 +13,7 @@ class Report(Base):
     chat_result = Column(Text, nullable=False, default="")
     ad8test_result = Column(Text, nullable=False, default="")
     soundtest_result = Column(Text, nullable=False, default="")
-    final_result = Column(Text, nullable=False, default="")  # 최종 소견 추가
     recommendation = Column(Text, nullable=False, default="")
-
     total_score = Column(Integer, nullable=False, default=0)
-    sound_score = Column(Integer, nullable=False, default=0)
-    ad8_score = Column(Integer, nullable=False, default=0)
-    drawing_score = Column(Integer, nullable=False, default=0)
-    text_score = Column(Integer, nullable=False, default=0)
-    memory_score = Column(Integer, nullable=False, default=0)
-    time_space_score = Column(Integer, nullable=False, default=0)
-    judgment_score = Column(Integer, nullable=False, default=0)
-    visual_score = Column(Integer, nullable=False, default=0)
-    language_score = Column(Integer, nullable=False, default=0)
 
     user = relationship("User", back_populates="reports")

--- a/backend/app/report/schemas.py
+++ b/backend/app/report/schemas.py
@@ -6,18 +6,8 @@ class ReportCreate(BaseModel):
     chat_result: str = ""
     ad8test_result: str = ""
     soundtest_result: str = ""
-    final_result: str = ""
     recommendation: str = ""
     total_score: int = 0
-    sound_score: int = 0
-    ad8_score: int = 0
-    drawing_score: int = 0
-    text_score: int = 0
-    memory_score: int = 0
-    time_space_score: int = 0
-    judgment_score: int = 0
-    visual_score: int = 0
-    language_score: int = 0
 
 class ReportResponse(BaseModel):
     report_id: int
@@ -30,4 +20,4 @@ class ReportResponse(BaseModel):
     total_score: int
 
     class Config:
-        orm_mode = True
+        from_attributes = True

--- a/backend/app/report/service.py
+++ b/backend/app/report/service.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 from . import crud, schemas
 
-def create_empty_report_service(db: Session, report: schemas.ReportCreate):
+def create_report_service(db: Session, report: schemas.ReportCreate):
     # 모든 필드를 명시적으로 전달
     empty_report_data = schemas.ReportCreate(
         user_id=report.user_id,
@@ -9,17 +9,7 @@ def create_empty_report_service(db: Session, report: schemas.ReportCreate):
         chat_result="",
         ad8test_result="",
         soundtest_result="",
-        final_result="",
         recommendation="",
-        total_score=0,
-        sound_score=0,
-        ad8_score=0,
-        drawing_score=0,
-        text_score=0,
-        memory_score=0,
-        time_space_score=0,
-        judgment_score=0,
-        visual_score=0,
-        language_score=0
+        total_score=0
     )
-    return crud.create_empty_report(db, empty_report_data)
+    return crud.create_report(db, empty_report_data)

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,8 @@ from app.auth import models
 from app import database
 from app.auth import api
 from app.report import api as report_api
-from app.trans import stt as stt_api  # ← STT 라우터도 함께 연결
+from app.trans import stt as stt_api
+from app.ad8 import api as ad8_api
 
 # DB 테이블 생성
 models.Base.metadata.create_all(bind=database.engine)
@@ -17,8 +18,9 @@ app = FastAPI(
 
 # 라우터 등록
 app.include_router(api.router, prefix="/user", tags=["User"])
-app.include_router(report_api.router)
+app.include_router(report_api.router, prefix="/reports", tags=["Report"])
 app.include_router(stt_api.router, prefix="/api", tags=["STT"])
+app.include_router(ad8_api.router, tags=["AD8"])
 
 @app.get("/")
 def root():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,3 +20,7 @@ python-jose==3.3.0
 passlib[bcrypt]==1.7.4
 cryptography
 tenacity
+openai
+python-dotenv
+httpx
+python-multipart


### PR DESCRIPTION
## 📌 PR 제목
- [ ] 기능 추가
- [v] 버그 수정
- [ ] 문서 변경
- [ ] 기타

## 📋 작업한 내용
- AD8 검사 응답 데이터를 처리하고 DB에 저장하는 API 구현
- AD8Test 및 AD8Response 모델/CRUD/스키마 생성
- AD8 결과를 report 테이블과 연동하여 risk_score 및 ad8test_result 업데이트
- FastAPI 라우터에 AD8 API 등록
- requirements.txt에 관련 패키지 추가 (openai, dotenv 등)

## 📸 Swagger 캡처 (필수)
<img width="1262" height="904" alt="image" src="https://github.com/user-attachments/assets/84c791af-1619-4042-bf02-6a9ad88b4cd0" />
<img width="1202" height="531" alt="image" src="https://github.com/user-attachments/assets/5a54a3d3-075a-4d8d-a366-7934ee1ed415" />
<img width="1234" height="876" alt="image" src="https://github.com/user-attachments/assets/eef713bf-f166-40bc-a073-ef106d94db46" />
<img width="1224" height="407" alt="image" src="https://github.com/user-attachments/assets/659d0427-8ec7-4aba-b1ba-fd3b01af11a5" />


## 🧪 테스트 여부
- [v] Swagger로 API 동작 확인
- [ ] 기타 테스트 완료

## 🔗 관련 이슈
- Close #106 

