### PR TITLE
Feat/chat stream status tracking 161

### DIFF
--- a/backend/app/chat/stream_handler.py
+++ b/backend/app/chat/stream_handler.py
@@ -11,12 +11,12 @@ from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate, H
 
 from app.chat.memory_store import get_memory
 
-# ✅ 환경변수에서 OpenAI 키 로드
+# 환경변수에서 OpenAI 키 로드
 openai_api_key = os.environ.get("OPENAI_API_KEY")
 if not openai_api_key:
     raise RuntimeError("OPENAI_API_KEY 환경변수가 설정되어 있지 않습니다.")
 
-# ✅ Chroma 벡터 DB 클라이언트 생성
+# Chroma 벡터 DB 클라이언트 생성
 client = chromadb.HttpClient(host="chroma-server", port=8000)
 vectordb = Chroma(
     client=client,
@@ -24,7 +24,7 @@ vectordb = Chroma(
     embedding_function=OpenAIEmbeddings(openai_api_key=openai_api_key)
 )
 
-# ✅ 프롬프트 템플릿 정의 (chat_with_ai와 동일하게)
+# 프롬프트 템플릿 정의 (chat_with_ai와 동일하게)
 system_prompt = """
 당신은 친근한 대화 파트너입니다.
 - 제공된 참고 논문(Context)을 활용해 실제 연구에서 사용된 치매 선별 질문을 자연스럽고 일상 대화로 묻습니다.
@@ -46,7 +46,7 @@ prompt = ChatPromptTemplate.from_messages([
     )
 ])
 
-# ✅ 스트리밍 처리용 체인 생성 함수
+# 스트리밍 처리용 체인 생성 함수
 def get_streaming_chain(report_id: int):
     memory = get_memory(report_id)
     handler = AsyncIteratorCallbackHandler()

--- a/backend/app/chat/stream_state.py
+++ b/backend/app/chat/stream_state.py
@@ -1,0 +1,22 @@
+# app/chat/stream_state.py
+
+# 현재 스트리밍 중인 chat_id들을 추적하는 집합
+_active_streams: set[int] = set()
+
+def is_streaming(chat_id: int) -> bool:
+    """
+    현재 chat_id가 스트리밍 중인지 확인합니다.
+    """
+    return chat_id in _active_streams
+
+def mark_stream_start(chat_id: int) -> None:
+    """
+    해당 chat_id의 스트리밍을 시작으로 표시합니다.
+    """
+    _active_streams.add(chat_id)
+
+def mark_stream_end(chat_id: int) -> None:
+    """
+    해당 chat_id의 스트리밍을 종료로 표시합니다.
+    """
+    _active_streams.discard(chat_id)


### PR DESCRIPTION
## 📌 PR 제목
- [v] 기능 추가
- [ ] 버그 수정
- [ ] 문서 변경
- [ ] 기타

## 📋 작업한 내용
- 채팅 스트리밍 중복 요청을 방지하기 위한 상태 관리 유틸 stream_state.py 추가
- is_streaming, mark_stream_start, mark_stream_end 함수 정의
- /chat/stream API에서 중복 스트리밍 요청 차단 로직 적용
- 스트리밍 시작, 종료, 예외 발생 시 상태 초기화 및 로그 저장
- 기존 직접 정의된 상태 관리 함수 → stream_state 모듈로 분리 및 리팩터링

## 🔗 관련 이슈
- Close #161 

