### PR TITLE
Feat/chat log by chat id 163

### DIFF
--- a/backend/app/chat/api.py
+++ b/backend/app/chat/api.py
@@ -15,7 +15,7 @@ from app.chat.schemas import (
 from app.chat.models import RoleEnum, Chat
 from app.chat.service import (
     chat_with_ai, evaluate_and_save_chat_result,
-    get_chat_logs_by_report_id
+    get_chat_logs_by_report_id, get_chat_logs
 )
 from app.chat.crud import save_chat_log
 from app.chat.stream_handler import get_streaming_chain
@@ -120,9 +120,22 @@ def create_chat(
     )
 
 
-@router.get("/chat/logs/by-report/{report_id}", response_model=list[ChatLogResponse])
+@router.get("/logs/{report_id}", response_model=list[ChatLogResponse])
 def get_logs_by_report_id(report_id: int, db: Session = Depends(get_db)):
     return get_chat_logs_by_report_id(db, report_id)
+
+@router.get(
+    "/logs/{chat_id}",
+    response_model=list[ChatLogResponse],
+    summary="채팅 로그 조회",
+    description="특정 chat_id에 대한 모든 채팅 로그를 반환합니다."
+)
+def read_chat_logs(
+        chat_id: int,
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_user)
+):
+    return get_chat_logs(db, chat_id)
 
 @router.post(
     "/chats/{chat_id}/evaluate",

--- a/backend/app/chat/service.py
+++ b/backend/app/chat/service.py
@@ -167,6 +167,15 @@ def get_chat_logs_by_report_id(db: Session, report_id: int) -> list[ChatLogRespo
     )
     return [ChatLogResponse.from_orm(log) for log in logs]
 
+def get_chat_logs(db: Session, chat_id: int) -> list[ChatLogResponse]:
+    logs = (
+        db.query(ChatLog)
+        .filter(ChatLog.chat_id == chat_id)
+        .order_by(ChatLog.updated_at.asc())  # updated_at 기준 오름차순
+        .all()
+    )
+    return [ChatLogResponse.from_orm(log) for log in logs]
+
 def evaluate_and_save_chat_result(db, chat_id: int, report_id: int):
     logs = (
         db.query(ChatLog)


### PR DESCRIPTION
## 📌 PR 제목
- [v] 기능 추가
- [ ] 버그 수정
- [ ] 문서 변경
- [ ] 기타

## 📋 작업한 내용
- API 엔드포인트 추가
 GET /chat/logs/{chat_id}
 특정 채팅방(chat_id)에 대한 전체 채팅 로그를 반환
- 서비스 함수 작성
 get_chat_logs(db: Session, chat_id: int)
 해당 chat_id의 채팅 로그를 DB에서 조회하여 ChatLogResponse 리스트로 반환
- 인증 처리
 Depends(get_current_user)를 통해 인증된 사용자만 로그를 조회할 수 있도록 설정

## 📸 Swagger 캡처 (필수)
<img width="1159" height="1377" alt="image" src="https://github.com/user-attachments/assets/614e3fbe-b0ea-483a-8601-d01087fcb9d2" />


## 🧪 테스트 여부
- [v] Swagger로 API 동작 확인
- [ ] 기타 테스트 완료

## 🔗 관련 이슈
- Close #163 

