### PR TITLE
feat(deploy): docker-compose profiles를 이용한 파이프라인 실행 분리#187

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+    profiles:
+      - setup
     command:
       - python
       - -u


### PR DESCRIPTION
## 📌 PR 제목
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 문서 변경
- [ ] 기타

## 📋 작업한 내용
docker-compose.yml의 pipeline 서비스에 profiles 기능을 적용하여, 명시적으로 호출할 때만 실행되도록 구성을 변경합니다.
기본 실행: docker-compose up 명령어로는 pipeline을 제외한 서비스만 실행됩니다.
초기화 작업 실행: docker-compose run --rm --build pipeline 명령어로 pipeline 서비스만 별도로 실행할 수 있습니다.

## 📸 Swagger 캡처 (필수)
<img width="1183" height="481" alt="image" src="https://github.com/user-attachments/assets/ab4ec48c-ae18-42da-8239-63b20f99a29e" />


## 🧪 테스트 여부
- [ ] Swagger로 API 동작 확인
- [v] 기타 테스트 완료

## 🔗 관련 이슈
- Close #194 

